### PR TITLE
Install libpython2.7-dev

### DIFF
--- a/2.2-ubuntu14.04/Dockerfile
+++ b/2.2-ubuntu14.04/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get install -y \
   rsync \
   clang \
   libicu-dev \
-  libedit-dev
+  libedit-dev \
+  libpython2.7-dev
   
 ENV SWIFT_VERSION 2.2-SNAPSHOT-2015-12-01-b
 ENV SWIFT_PLATFORM ubuntu14.04

--- a/2.2-ubuntu15.10/Dockerfile
+++ b/2.2-ubuntu15.10/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get install -y \
   wget \
   rsync \
   clang \
-  libicu-dev
+  libicu-dev \
+  libpython2.7-dev
   
 ENV SWIFT_VERSION 2.2-SNAPSHOT-2015-12-01-b
 ENV SWIFT_PLATFORM ubuntu15.10


### PR DESCRIPTION
This fixes the top-level `Swift` command.

Before:

    % docker run --rm -it swiftlang/swift swift
    /usr/bin/lldb: error while loading shared libraries: libpython2.7.so.1.0: cannot open shared object file: No such file or directory

After:

    % docker run --rm -it swiftlang/swift swift
    Welcome to Swift version 2.2-dev (LLVM 46be9ff861, Clang 4deb154edc, Swift 778f82939c). Type :help for assistance.
      1>

Fixes #1 
Replaces #2 